### PR TITLE
[Feature] Set both user clocks to the same high frequency in auto mode during quartus_fit

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/par/user_clock_config.tcl
+++ b/plat_if_develop/ofs_plat_if/src/par/user_clock_config.tcl
@@ -42,11 +42,14 @@ proc get_aligned_user_clock_targets {afu_json_uclk_freqs freq_max} {
 
     if {0 == [string compare -nocase -length 4 "auto" $uclk_freq_high]} {
         # High frequency clock is "auto".  Initially, constrain it
-        # to a maximum frequency.  Also, ignore the JSON constraint
-        # on the low frequency clock and constrain it to half of
-        # freq_max.
+        # to a maximum frequency. We ignore the JSON constraint
+        # on the low frequency clock and constrain it to the same
+        # freq_max. The low frequency clock gets a high constraint
+        # in case the high frequency clock is unused. Some OneAPI
+        # designs use only the low frequency clock and expect that
+        # it is allowed to go above $freq_max / 2.
         set uclk_freq_high [uclk_parse_auto_freq $uclk_freq_high $freq_max]
-        set uclk_freq_low [expr {$uclk_freq_high / 2.0}]
+        set uclk_freq_low [uclk_parse_auto_freq $uclk_freq_low $freq_max]
 
         post_message "Target user clock high: auto ($uclk_freq_high)"
         post_message "Target user clock low: auto ($uclk_freq_low)"


### PR DESCRIPTION
### Description
The FIM's scripts now detect when only uclk_div2 is used, allowing for frequencies faster than max freq / 2. Run the fitter with an aggressive target in case uclk is not used.

### Collateral (docs, reports, design examples, case IDs):

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:

### Tests run:
Tested along with the corresponding FIM change.