### PR TITLE
Fix AVMM completion generation when mapping split to shared bus

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/prims/ofs_plat_avalon_mem_rdwr_if_to_mem_if.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/base_ifcs/avalon/prims/ofs_plat_avalon_mem_rdwr_if_to_mem_if.sv
@@ -218,15 +218,18 @@ module ofs_plat_avalon_mem_rdwr_if_to_mem_if
         end
         else
         begin
-            // Response generated here as writes win arbitrarion
-            mem_source.wr_writeresponsevalid <= arb_grant_write && !mem_sink.waitrequest &&
-                                                !wr_burst_active;
+            // Response generated here as writes complete
+            mem_source.wr_writeresponsevalid <= mem_sink.write && !mem_sink.waitrequest &&
+                                                wr_req.eop;
             mem_source.wr_response <= '0;
 
-            if (PRESERVE_WR_RESPONSE_USER != 0)
-                mem_source.wr_writeresponseuser <= wr_req.user;
-            else
-                mem_source.wr_writeresponseuser <= '0;
+            if (arb_grant_write && !mem_sink.waitrequest && !wr_burst_active)
+            begin
+                if (PRESERVE_WR_RESPONSE_USER != 0)
+                  mem_source.wr_writeresponseuser <= wr_req.user;
+                else
+                  mem_source.wr_writeresponseuser <= '0;
+            end
         end
 
         if (!reset_n)


### PR DESCRIPTION
The logic that generated a write commit when mapping split bus AVMM to a shared bus generated the commit at the start of a write. Instead, it should wait for the last beat of the write.
