### PR TITLE
[Fix] - Incorrect offset to VF index in ASE PF/VF MUX emulator

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/sim/mux/ase_emul_pf_vf_mux_top.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/host_chan/native_axis_pcie_tlp/prims/gasket_pcie_ss/sim/mux/ase_emul_pf_vf_mux_top.sv
@@ -123,8 +123,8 @@ module ase_emul_pf_vf_mux_top                                                   
 
     function automatic [NID_WIDTH:0] pfvf_to_port(input [PFVF_WIDTH-1:0] pfvf);
         // For simulation, port index is just the VF index. The field
-        // is layed out { VF index, VF active, PF index }.
-        return pfvf[pcie_ss_hdr_pkg::PF_WIDTH+1 +: NID_WIDTH];
+        // is layed out { VF active, VF index, PF index }.
+        return pfvf[pcie_ss_hdr_pkg::PF_WIDTH +: NID_WIDTH];
     endfunction
 
     always @(*) begin                                                                //  


### PR DESCRIPTION
### Description
Emulated PF/VF MUX computed port index incorrectly.

Only used by ASE with d5005

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
examples-afu/tutorial/afu_types/02_hybrid/hello_world