### PR TITLE
Sever PIM<->FIM local memory buser connection.

### DIFF
--- a/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/local_mem/native_axi/prims/gasket_fim_emif_axi_mm/map_fim_emif_axi_mm_to_local_mem.sv
+++ b/plat_if_develop/ofs_plat_if/src/rtl/ifc_classes/local_mem/native_axi/prims/gasket_fim_emif_axi_mm/map_fim_emif_axi_mm_to_local_mem.sv
@@ -58,7 +58,7 @@ module map_fim_emif_axi_mm_to_local_mem
         afu_mem_bank.b = '0;
         afu_mem_bank.b.id = fim_mem_bank.bid;
         afu_mem_bank.b.resp = fim_mem_bank.bresp;
-        afu_mem_bank.b.user = fim_mem_bank.buser;
+        // afu_mem_bank.b.user = fim_mem_bank.buser;
     end
 
     assign afu_mem_bank.arready = fim_mem_bank.arready;
@@ -150,7 +150,7 @@ module map_local_mem_to_fim_emif_axi_mm
     assign fim_mem_bank.bvalid = pim_mem_bank.bvalid;
     assign fim_mem_bank.bid = pim_mem_bank.b.id;
     assign fim_mem_bank.bresp = pim_mem_bank.b.resp;
-    assign fim_mem_bank.buser = pim_mem_bank.b.user;
+    // assign fim_mem_bank.buser = pim_mem_bank.b.user;
 
     assign fim_mem_bank.arready = pim_mem_bank.arready;
     assign pim_mem_bank.arvalid = fim_mem_bank.arvalid;


### PR DESCRIPTION
### Description

The memory controller for new silicon (FP8/SM) doesn't have this field as a part of it's interface definition so there is no driver.

### Tests run:

he_mem_lb unit test w/ HBM